### PR TITLE
バグを修正しました fixed a bug ☘

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -254,9 +254,8 @@ int main()
 
 				ray.o = hit.p;
 
-				th = th * sph.R; //updating throughput
-
 				ray.d = sample_hemisphere(rng.next(), rng.next(), hit.n);
+				th = th * sph.R * dot(hit.n, ray.d) * 2; //updating throughput
 
 				if (max({ th.x,th.y,th.z }) == 0.)
 					break; // if throughput is too low


### PR DESCRIPTION
サンプリングの計算にあったバグを修正しました☘

オリジナルのソースではcosine weightedな分布からサンプリングをしていましたが、頂いたバージョンでは半球上の一様分布からサンプリングをしているようです。この場合、throughputの更新は以下のようになります。立体角測度でのpdf = 1 / (2*pi) で、BRDFがf_s = R / piなので、

`th *= f_s / pdf * cos = sph.R * dot(hit.n, ray.d) * 2`

となります。

---

I fixed a bug in the sampling computation. ☘

In the original code, I sampled a direction from the cosine-weighted distribution. It seems in your code the sampling function was modified to sample a direction uniformly on the unit hemisphere. In this case, the update code for the throughput becomes

`th *= f_s / pdf * cos = sph.R * dot(hit.n, ray.d) * 2`

where f_s = R / pi is a BRDF for diffuse surface and pdf = 1 / (2*pi) is a pdf on the solid angle measure.


